### PR TITLE
Fix build for Darwin

### DIFF
--- a/mk/base.mk
+++ b/mk/base.mk
@@ -51,7 +51,7 @@ TEST	= /usr/bin/test
 endif # CYGWIN
 
 ifeq (${HOST_OS}, Darwin)
-_OSVER := $(shell /usr/sbin/sysctl -n kern.osrelease)
+_OSVER := $(shell /usr/sbin/sysctl -n kern.osrelease | cut -d . -f 1)
 OSVER  ?= ${_OSVER}
 BINGRP	= admin
 endif # Darwin

--- a/mk/hash.mk
+++ b/mk/hash.mk
@@ -40,7 +40,12 @@ HASH_TYPE      ?= none
 endif # CYGWIN
 
 ifeq (${HOST_OS}, Darwin)
-HASH_TYPE      ?= none
+ifeq ($(shell ${TEST} ${OSVER} -lt 15 && ${ECHO} yes), yes)
+HASH_TYPE      ?= openssl
+endif
+ifeq ($(shell ${TEST} ${OSVER} -gt 15 && ${ECHO} yes), yes)
+HASH_TYPE      ?= native
+endif
 endif # Darwin
 
 ifeq (${HOST_OS}, Linux)

--- a/mk/network.mk
+++ b/mk/network.mk
@@ -48,21 +48,9 @@ endif # CYGWIN
 
 ifeq (${HOST_OS}, Darwin)
 HAVE_SOCKLEN_T ?= no
-ifeq ($(shell ${TEST} ${OSVER} = "12.0.0" && ${ECHO} yes), yes) # OS X 10.8
+ifeq ($(shell ${TEST} ${OSVER} -ge 12 && ${ECHO} yes), yes) # OS X 10.8+
 HAVE_SOCKLEN_T	= yes
-endif # OS X 10.8
-ifeq ($(shell ${TEST} ${OSVER} = "12.3.0" && ${ECHO} yes), yes) # OS X 10.8.2
-HAVE_SOCKLEN_T	= yes
-endif # OS X 10.8.2
-ifeq ($(shell ${TEST} ${OSVER} = "12.4.0" && ${ECHO} yes), yes) # OS X 10.8.4
-HAVE_SOCKLEN_T	= yes
-endif # OS X 10.8.4
-ifeq ($(shell ${TEST} ${OSVER} = "12.5.0" && ${ECHO} yes), yes) # OS X 10.8.5
-HAVE_SOCKLEN_T	= yes
-endif # OS X 10.8.5
-ifeq ($(shell ${TEST} ${OSVER} = "13.0.0" && ${ECHO} yes), yes) # OS X 10.9
-HAVE_SOCKLEN_T	= yes
-endif # OS X 10.9
+endif
 ifeq (${HAVE_SOCKLEN_T}, no)
 CFLAGS += -Dsocklen_t=int
 endif # HAVE_SOCKLEN_T


### PR DESCRIPTION
cvsync doesn't build on Darwin currently. I've simplified the OS version testing by cutting the Darwin version down to its major integer. I've also changed the makefiles it so uses native hashing after CoreCrypto was introduced, and OpenSSL on versions before that (when OpenSSL was included). 